### PR TITLE
Feature: Add "Remove ALL items" option to settings

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -271,6 +271,18 @@ button:not(.star-btn):not(.trash-btn):not(.icon-btn):disabled {
   cursor: not-allowed;
 }
 
+.btn-danger {
+  background: #fee2e2;
+  border-color: #fecaca;
+  color: #991b1b;
+}
+
+.btn-danger:hover {
+  background: #fecaca;
+  border-color: #fca5a5;
+  color: #7f1d1d;
+}
+
 /* Icon buttons */
 .star-btn,
 .trash-btn {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -143,6 +143,13 @@ const Popup = () => {
     chrome.storage.local.set({ copiedItems: kept });
   };
 
+  const clearAllItems = () => {
+    if (window.confirm('Are you sure you want to delete all items, including favorites? This cannot be undone.')) {
+      setAllItems([]);
+      chrome.storage.local.set({ copiedItems: [] });
+    }
+  };
+
   const hasNonFavorites = allItems.some(item => !item.favorite);
 
   const handleItemClick = async (item: CopiedItem) => {
@@ -347,6 +354,19 @@ const Popup = () => {
                     </p>
                   )}
                 </div>
+
+                <div style={{ borderTop: '1px solid var(--border)', margin: '16px 0' }} />
+
+                <button
+                  className="btn-danger"
+                  onClick={clearAllItems}
+                  disabled={allItems.length === 0}
+                >
+                  Remove ALL items
+                </button>
+                <p style={{ marginTop: 6, color: 'var(--muted)' }}>
+                  This will permanently delete all copied items, including your favorites.
+                </p>
               </div>
             </div>
           </div>
@@ -489,6 +509,19 @@ const Popup = () => {
                   </p>
                 )}
               </div>
+
+              <div style={{ borderTop: '1px solid var(--border)', margin: '16px 0' }} />
+
+              <button
+                className="btn-danger"
+                onClick={clearAllItems}
+                disabled={allItems.length === 0}
+              >
+                Remove ALL items
+              </button>
+              <p style={{ marginTop: 6, color: 'var(--muted)' }}>
+                This will permanently delete all copied items, including your favorites.
+              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
**Description**
This PR introduces a new feature that allows users to permanently delete all stored clipboard items, including favorites, from the settings page. To prevent accidental data loss, this action is behind a confirmation dialog. The button is styled in red to clearly signify a destructive operation.
**Changes:**
•New clear AllItems function: Added a function in popup.tsx that: 1.Prompts the user with a window.confirm() dialog. 2. If confirmed, clears the allItems state array. 3 .Updates chrome.storage.local to persist the empty item list.•Settings Modal Button:•A "Remove ALL items" button is added to the bottom of the settings modal in both the main and "View All" views.•The button is disabled when there are no items to remove.•New CSS Styling:•A .btn-danger class was added to popup.css to give the button a distinct red color, indicating a destructive action.